### PR TITLE
Add Patch to CoreDNS

### DIFF
--- a/coredns/config/crds/addons_v1alpha1_coredns.yaml
+++ b/coredns/config/crds/addons_v1alpha1_coredns.yaml
@@ -27,8 +27,30 @@ spec:
         metadata:
           type: object
         spec:
+          properties:
+            channel:
+              description: 'Channel specifies a channel that can be used to resolve
+                a specific addon, eg: stable It will be ignored if Version is specified'
+              type: string
+            patches:
+              items:
+                type: object
+              type: array
+            version:
+              description: Version specifies the exact addon version to be deployed,
+                eg 1.2.3 It should not be specified if Channel is specified
+              type: string
           type: object
         status:
+          properties:
+            errors:
+              items:
+                type: string
+              type: array
+            healthy:
+              type: boolean
+          required:
+          - healthy
           type: object
   version: v1alpha1
 status:

--- a/coredns/config/rbac/manager_role.yaml
+++ b/coredns/config/rbac/manager_role.yaml
@@ -70,7 +70,7 @@ rules:
   - ""
   resources:
   - endpoints
-  - namespaced
+  - namespaces
   - nodes
   - pods
   verbs:

--- a/coredns/config/samples/addons_v1alpha1_coredns.yaml
+++ b/coredns/config/samples/addons_v1alpha1_coredns.yaml
@@ -5,3 +5,11 @@ metadata:
   namespace: kube-system
 spec:
   channel: stable
+  patches:
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: coredns
+      namespace: kube-system
+      labels:
+        foo: bar

--- a/coredns/go.mod
+++ b/coredns/go.mod
@@ -93,7 +93,7 @@ require (
 	k8s.io/utils v0.0.0-20190308190857-21c4ce38f2a7 // indirect
 	sigs.k8s.io/controller-runtime v0.1.10
 	sigs.k8s.io/controller-tools v0.1.10
-	sigs.k8s.io/kubebuilder-declarative-pattern v0.0.0-20190404154250-8bafc34fd655
+	sigs.k8s.io/kubebuilder-declarative-pattern v0.0.0-20190624171758-3bfb5869c8b7
 	sigs.k8s.io/structured-merge-diff v0.0.0-20190302045857-e85c7b244fd2 // indirect
 	sigs.k8s.io/testing_frameworks v0.1.1 // indirect
 	sigs.k8s.io/yaml v1.1.0 // indirect

--- a/coredns/go.sum
+++ b/coredns/go.sum
@@ -274,6 +274,8 @@ sigs.k8s.io/controller-tools v0.1.10 h1:onJbaVxkLKbLhy3BcLdesjkP6y+6WFVzg1BJv28B
 sigs.k8s.io/controller-tools v0.1.10/go.mod h1:6g08p9m9G/So3sBc1AOQifHfhxH/mb6Sc4z0LMI8XMw=
 sigs.k8s.io/kubebuilder-declarative-pattern v0.0.0-20190404154250-8bafc34fd655 h1:xzJa5Jmx3J18LQZeAWSbSPCcorx36asgETRwoCjD7wk=
 sigs.k8s.io/kubebuilder-declarative-pattern v0.0.0-20190404154250-8bafc34fd655/go.mod h1:ykt5oDuxE2+6o1OMDpAjLqFRzPdf4OHnCpvftPsUIIc=
+sigs.k8s.io/kubebuilder-declarative-pattern v0.0.0-20190624171758-3bfb5869c8b7 h1:MJsfBngQLTX7v99ZsNEJLtpX1n5mzKesZxRfgb6De2M=
+sigs.k8s.io/kubebuilder-declarative-pattern v0.0.0-20190624171758-3bfb5869c8b7/go.mod h1:ykt5oDuxE2+6o1OMDpAjLqFRzPdf4OHnCpvftPsUIIc=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190302045857-e85c7b244fd2/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/testing_frameworks v0.1.1 h1:cP2l8fkA3O9vekpy5Ks8mmA0NW/F7yBdXf8brkWhVrs=
 sigs.k8s.io/testing_frameworks v0.1.1/go.mod h1:VVBKrHmJ6Ekkfz284YKhQePcdycOzNH9qL6ht1zEr/U=

--- a/coredns/pkg/apis/addons/v1alpha1/coredns_types.go
+++ b/coredns/pkg/apis/addons/v1alpha1/coredns_types.go
@@ -22,15 +22,17 @@ import (
 
 // CoreDNSSpec defines the desired state of CoreDNS
 type CoreDNSSpec struct {
-	addonv1alpha1.CommonSpec
+	addonv1alpha1.CommonSpec `json:",inline"`
+	addonv1alpha1.PatchSpec  `json:",inline"`
 }
 
 // CoreDNSStatus defines the observed state of CoreDNS
 type CoreDNSStatus struct {
-	addonv1alpha1.CommonStatus
+	addonv1alpha1.CommonStatus `json:",inline"`
 }
 
 var _ addonv1alpha1.CommonObject = &CoreDNS{}
+var _ addonv1alpha1.Patchable = &CoreDNS{}
 
 func (c *CoreDNS) ComponentName() string {
 	return "coredns"
@@ -46,6 +48,10 @@ func (c *CoreDNS) GetCommonStatus() addonv1alpha1.CommonStatus {
 
 func (c *CoreDNS) SetCommonStatus(s addonv1alpha1.CommonStatus) {
 	c.Status.CommonStatus = s
+}
+
+func (c *CoreDNS) PatchSpec() addonv1alpha1.PatchSpec {
+	return c.Spec.PatchSpec
 }
 
 // +genclient

--- a/coredns/pkg/apis/addons/v1alpha1/zz_generated.deepcopy.go
+++ b/coredns/pkg/apis/addons/v1alpha1/zz_generated.deepcopy.go
@@ -27,7 +27,7 @@ func (in *CoreDNS) DeepCopyInto(out *CoreDNS) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
-	out.Spec = in.Spec
+	in.Spec.DeepCopyInto(&out.Spec)
 	in.Status.DeepCopyInto(&out.Status)
 	return
 }
@@ -87,6 +87,7 @@ func (in *CoreDNSList) DeepCopyObject() runtime.Object {
 func (in *CoreDNSSpec) DeepCopyInto(out *CoreDNSSpec) {
 	*out = *in
 	out.CommonSpec = in.CommonSpec
+	in.PatchSpec.DeepCopyInto(&out.PatchSpec)
 	return
 }
 

--- a/coredns/pkg/controller/coredns/coredns_controller.go
+++ b/coredns/pkg/controller/coredns/coredns_controller.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+	"sigs.k8s.io/kubebuilder-declarative-pattern/pkg/patterns/addon"
 	"sigs.k8s.io/kubebuilder-declarative-pattern/pkg/patterns/addon/pkg/status"
 	"sigs.k8s.io/kubebuilder-declarative-pattern/pkg/patterns/declarative"
 )
@@ -76,6 +77,7 @@ func newReconciler(mgr manager.Manager) *ReconcileCoreDNS {
 		declarative.WithOwner(declarative.SourceAsOwner),
 		declarative.WithLabels(declarative.SourceLabel(mgr.GetScheme())),
 		declarative.WithStatus(status.NewBasic(mgr.GetClient())),
+		declarative.WithObjectTransform(addon.ApplyPatches),
 	)
 
 	return r


### PR DESCRIPTION
Based on functionality added in kubernetes-sigs/kubebuilder-declarative-pattern#44

updates kubernetes-sigs/addon-operators#12