### PR TITLE
Write your own operator doc

### DIFF
--- a/coredns/README.md
+++ b/coredns/README.md
@@ -4,7 +4,7 @@ Broadly based on [kubebuilder-declarative-pattern walkthrough](https://github.co
 
 A few differences so we can use go modules and [crane](https://github.com/google/go-containerregistry/blob/master/cmd/crane/doc/crane.md) - neither of which are required, just personal preference.
 
-Created with kubebuilder:
+Created with kubebuilder v1 (v2 will provide you with a different directory structure).
 
 ```bash
 kubebuilder init --dep=false --domain=k8s.io --license apache2

--- a/writing-an-addon-operator.md
+++ b/writing-an-addon-operator.md
@@ -2,13 +2,13 @@
 
 ## What is it
 
-The [Addons via Operators KEP](kep) discusses how operators can be used for managing cluster addons. The Cluster Addons sub-project has been discussing various approaches since the KEP was merged. Below we will discuss a simple example, which was the first addon operator that was reviewed and "blessed" by the team. It should be straight-forward and give you an idea of how to proceed writing your own addon operator.
+The [Addons via Operators KEP](kep) details how operators can be used for managing cluster addons. The Cluster Addons sub-project has been discussing various approaches since the KEP was merged. Below we will present a simple example, which was the first addon operator that was reviewed and "blessed" by the team. It should be straight-forward and give you an idea of how to proceed writing your own addon operator.
 
 ## An example
 
 Bringing up CoreDNS in a Kubernetes cluster was identified as a task that was clear and simple enough but still help us understand the general problem space and ask the right questions.
 
-You can review the code of the [CoreDNS addon operator](coredns-op) in this repository. We will discuss the most interesting parts of it here. [Its README](coredns-readme) describes how the code scaffolding for the operator was set up, using `kubebuilder` and the [kubebuilder-declarative-pattern](kdp).
+You can review the code of the [CoreDNS addon operator](coredns-op) in this repository. Here we will take you through the most interesting parts. [Its README](coredns-readme) describes how the code scaffolding for the operator was set up, using `kubebuilder` and the [kubebuilder-declarative-pattern](kdp).
 
 ### XXX: Breakdown structure of operator
 

--- a/writing-an-addon-operator.md
+++ b/writing-an-addon-operator.md
@@ -76,6 +76,8 @@ You can review the code of the [CoreDNS addon operator](coredns-op) in this repo
 
 ### XXX: Discussion of things strictly related to the coredns operator
 
+Diff from `kubebuilder` boilerplate code to coredns addon operator can be viewed here: https://gist.github.com/dholbach/d3a4dd8b7c7d80508ab945f53ef51e09
+
 ### XXX: Running the operator
 
 ## Get started

--- a/writing-an-addon-operator.md
+++ b/writing-an-addon-operator.md
@@ -10,9 +10,86 @@ Bringing up CoreDNS in a Kubernetes cluster was identified as a task that was cl
 
 You can review the code of the [CoreDNS addon operator](coredns-op) in this repository. We will discuss the most interesting parts of it here. [Its README](coredns-readme) describes how the code scaffolding for the operator was set up, using `kubebuilder` and the [kubebuilder-declarative-pattern](kdp).
 
+### XXX: Breakdown structure of operator
+
+```sh
+.
+├── channels
+│   ├── packages
+│   │   └── coredns
+│   │       └── 1.3.1
+│   │           ├── coredns.yaml.base
+│   │           └── manifest.yaml
+│   └── stable
+├── cmd
+│   └── manager
+│       └── main.go
+├── config
+│   ├── crds
+│   │   └── addons_v1alpha1_coredns.yaml
+│   ├── default
+│   │   ├── kustomization.yaml
+│   │   ├── manager_auth_proxy_patch.yaml
+│   │   ├── manager_image_patch.yaml
+│   │   └── manager_prometheus_metrics_patch.yaml
+│   ├── manager
+│   │   └── manager.yaml
+│   ├── rbac
+│   │   ├── auth_proxy_role_binding.yaml
+│   │   ├── auth_proxy_role.yaml
+│   │   ├── auth_proxy_service.yaml
+│   │   ├── manager_role_binding.yaml
+│   │   └── manager_role.yaml
+│   └── samples
+│       └── addons_v1alpha1_coredns.yaml
+├── go.mod
+├── go.sum
+├── hack
+│   └── boilerplate.go.txt
+├── k8s
+│   └── manager.yaml
+├── Makefile
+├── pkg
+│   ├── apis
+│   │   ├── addons
+│   │   │   ├── group.go
+│   │   │   └── v1alpha1
+│   │   │       ├── coredns_types.go
+│   │   │       ├── doc.go
+│   │   │       ├── register.go
+│   │   │       └── zz_generated.deepcopy.go
+│   │   ├── addtoscheme_addons_v1alpha1.go
+│   │   └── apis.go
+│   ├── controller
+│   │   ├── add_coredns.go
+│   │   ├── controller.go
+│   │   └── coredns
+│   │       └── coredns_controller.go
+│   └── webhook
+│       └── webhook.go
+├── PROJECT
+├── README.md
+└── tools.go
+```
+
+### XXX: Lifecycle of operator
+
+### XXX: Discussion of things strictly related to the coredns operator
+
+### XXX: Running the operator
+
 ## Get started
 
+XXX: Steal instructions from [coredns-readme].
+
 ## Talk to us
+
+If you are interested in this, want to explore addon operators, want to discuss or get stuck somewhere, please talk to us:
+
+- [#cluster-addons Slack](https://kubernetes.slack.com/messages/cluster-addons)
+- [SIG Cluster Lifecycle group](https://groups.google.com/forum/#!forum/kubernetes-sig-cluster-lifecycle)
+
+We appreciate your questions and feedback.
 
 [kep]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-cluster-lifecycle/addons/0035-20190128-addons-via-operators.md
 [coredns-op]: https://github.com/kubernetes-sigs/addon-operators/tree/master/coredns

--- a/writing-an-addon-operator.md
+++ b/writing-an-addon-operator.md
@@ -1,0 +1,20 @@
+# Writing an Addon Operator
+
+## What is it
+
+The [Addons via Operators KEP](kep) discusses how operators can be used for managing cluster addons. The Cluster Addons sub-project has been discussing various approaches since the KEP was merged. Below we will discuss a simple example, which was the first addon operator that was reviewed and "blessed" by the team. It should be straight-forward and give you an idea of how to proceed writing your own addon operator.
+
+## An example
+
+Bringing up CoreDNS in a Kubernetes cluster was identified as a task that was clear and simple enough but still help us understand the general problem space and ask the right questions.
+
+You can review the code of the [CoreDNS addon operator](coredns-op) in this repository. We will discuss the most interesting parts of it here. [Its README](coredns-readme) describes how the code scaffolding for the operator was set up, using `kubebuilder` and the [kubebuilder-declarative-pattern](kdp).
+
+## Get started
+
+## Talk to us
+
+[kep]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-cluster-lifecycle/addons/0035-20190128-addons-via-operators.md
+[coredns-op]: https://github.com/kubernetes-sigs/addon-operators/tree/master/coredns
+[coredns-readme]: https://github.com/kubernetes-sigs/addon-operators/blob/master/coredns/README.md
+[kdp]: https://github.com/kubernetes-sigs/kubebuilder-declarative-pattern


### PR DESCRIPTION
Opening this as a draft pull request to address #11. I wrote a little bit of text for the doc, but found I'll need help to read the diff between the boilerplate code that's provided by `kubebuilder` and what we have in https://github.com/kubernetes-sigs/addon-operators/tree/master/coredns.

Any help to finish this would be much appreciated, as we'll need this doc to reach out, get more people to kick the tires and give us feedback.

Side-point: I was actually a bit surprised by how many files moved around. Could we make it so that the differences are somewhat smaller, so that reading the diff gets really clear and people who attempt to write their own addon operator will have to move things around a bit less? (It could also well be that I made a mistake along the way somewhere...) @justinsb @johnsonj 